### PR TITLE
Make ZapCore creation customizable

### DIFF
--- a/otellogger.go
+++ b/otellogger.go
@@ -44,6 +44,14 @@ func NewOtelZapCore() zapcore.Core {
 	}
 }
 
+// NewCustomOtelZapCore allows for creating zapcore with customized logger,
+// giving thus greater flexibility
+func NewCustomOtelZapCore(logger logs.Logger) zapcore.Core {
+	return &OtelZapCore{
+		logger: logger,
+	}
+}
+
 // TODO: I guess there is more idomatic way to do this in go
 func AttachToZapLogger(logger *zap.Logger) *zap.Logger {
 	otelSdlDisabled, defined := os.LookupEnv(otelSdkDisabled)


### PR DESCRIPTION
As mentioned in the comment of the NewOtelZapCore function, it is not flexible enough and configuration through env vars is not always desired or possible.

This change adds a new method that allows creating ZapCore with custom logger which can be customized to hearts content. I have not changed the original function in order to not to break API.

CC: @blumamir 